### PR TITLE
Imu reset method

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ClawSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ClawSubsystem.java
@@ -35,7 +35,7 @@ public class ClawSubsystem extends SubsystemBase {
 
     }
     public void close() {
-        servo.setPosition(0.35);
+        servo.setPosition(0.45);
         closed = true;
 
         telemetry.addLine("claw closed");

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ClawSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ClawSubsystem.java
@@ -35,7 +35,7 @@ public class ClawSubsystem extends SubsystemBase {
 
     }
     public void close() {
-        servo.setPosition(0.45);
+        servo.setPosition(0.40);
         closed = true;
 
         telemetry.addLine("claw closed");

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ImuSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ImuSubsystem.java
@@ -25,7 +25,7 @@ public class ImuSubsystem extends SubsystemBase {
         imu = hardwareMap.get(IMU.class, "imu");
         this.telemetry = telemetry;
         imu.initialize(new IMU.Parameters(orientationOnRobot));
-        imu.resetYaw();
+        reset();
     }
 
     public void imuTelemetry() {
@@ -49,5 +49,9 @@ public class ImuSubsystem extends SubsystemBase {
     public void periodic() {
         imuTelemetry();
 
+    }
+
+    public void reset(){
+        imu.resetYaw();
     }
 }


### PR DESCRIPTION
Add a reset method for IMU so that it can be called in an Instance Command at the start of Auto to reduce the risk of the IMU pointing the wrong direction, from the robot sitting around powered up for too long.

Also increased servo setuppoint on grabber to give the grabber more grab. Was dripping pixels
